### PR TITLE
Filled out ModelStats methods

### DIFF
--- a/SUAPI-CppWrapper/model/Model.cpp
+++ b/SUAPI-CppWrapper/model/Model.cpp
@@ -403,7 +403,7 @@ size_t Model::num_faces() const {
     throw std::logic_error("CW::Model::num_faces(): Model is null");
   }
   ModelStatistics model_statistics((*this));
-  return model_statistics.num_faces();
+  return model_statistics.faces();
 }
 
 OptionsManager Model::options()
@@ -526,10 +526,40 @@ ModelStatistics::ModelStatistics(const Model& model):
   assert(res == SU_ERROR_NONE);
 }
   
-int ModelStatistics::num_faces() {
+int ModelStatistics::edges() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_Edge];
+}
+
+int ModelStatistics::faces() const
+{
   return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_Face];
 }
-  
+int ModelStatistics::instances() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_ComponentInstance];
+}
+int ModelStatistics::groups() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_Group];
+}
+int ModelStatistics::definitions() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_ComponentDefinition];
+}
+int ModelStatistics::layers() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_Layer];
+}
+int ModelStatistics::materials() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_Material];
+}
+int ModelStatistics::images() const
+{
+  return m_model_statistics.entity_counts[SUModelStatistics::SUEntityType_Image];
+}
+
   
 
 } /* namespace CW */

--- a/SUAPI-CppWrapper/model/Model.hpp
+++ b/SUAPI-CppWrapper/model/Model.hpp
@@ -321,8 +321,14 @@ class ModelStatistics {
   /**
   * Return the number of faces in the model.
   */
-  int num_faces();
-  
+  int faces() const;
+  int edges() const;
+  int instances() const;
+  int groups() const;
+  int images() const;
+  int definitions() const;
+  int layers() const;
+  int materials() const;
 };
 
 } /* namespace CW */


### PR DESCRIPTION
I decided to use the plural of each type to return the count.  You had started out using a prefix of `num_`, but in my mind that could be interpreted as a command to number the edges, which is why I avoided using it.

If you'd prefer, the methods could be named using a suffix `_count` so
`face_count()`
`edge_count()`

Let me know if you have a preference for naming these methods.

Example:

```cpp
 CW::ModelStatistics stats = CW::ModelStatistics(model);
  std::cout << "Stats:\n";
  std::cout << "\tEdges:       " << stats.edges() << "\n";
  std::cout << "\tFaces:       " << stats.faces() << "\n";
  std::cout << "\tDefinitions: " << stats.definitions() << "\n";
  std::cout << "\tInstances:   " << stats.instances() << "\n";
  std::cout << "\tGroups:      " << stats.groups() << "\n";
  std::cout << "\tLayers:      " << stats.layers() << "\n";
  std::cout << "\tMaterials:   " << stats.materials() << "\n";
  std::cout << "\tImages:      " << stats.images() << "\n";
```
