### PR TITLE
need to include <stdexcept> for std::logic_error

### DIFF
--- a/SUAPI-CppWrapper/model/AttributeDictionary.cpp
+++ b/SUAPI-CppWrapper/model/AttributeDictionary.cpp
@@ -26,6 +26,7 @@
 //
 
 #include <cassert>
+#include <stdexcept>
 #include <algorithm>
 
 #include "SUAPI-CppWrapper/model/AttributeDictionary.hpp"

--- a/SUAPI-CppWrapper/model/Curve.cpp
+++ b/SUAPI-CppWrapper/model/Curve.cpp
@@ -25,6 +25,7 @@
 // SOFTWARE.
 //
 #include <cassert>
+#include <stdexcept>
 
 #include "SUAPI-CppWrapper/model/Curve.hpp"
 

--- a/SUAPI-CppWrapper/model/DrawingElement.cpp
+++ b/SUAPI-CppWrapper/model/DrawingElement.cpp
@@ -27,6 +27,7 @@
 #include "SUAPI-CppWrapper/model/DrawingElement.hpp"
 
 #include <cassert>
+#include <stdexcept>
 
 #include "SUAPI-CppWrapper/model/Layer.hpp"
 #include "SUAPI-CppWrapper/model/Material.hpp"

--- a/SUAPI-CppWrapper/model/Edge.cpp
+++ b/SUAPI-CppWrapper/model/Edge.cpp
@@ -28,6 +28,7 @@
 #include "SUAPI-CppWrapper/model/Edge.hpp"
 
 #include <cassert>
+#include <stdexcept>
 
 #include "SUAPI-CppWrapper/Color.hpp"
 #include "SUAPI-CppWrapper/model/Vertex.hpp"

--- a/SUAPI-CppWrapper/model/Entity.cpp
+++ b/SUAPI-CppWrapper/model/Entity.cpp
@@ -28,6 +28,8 @@
 #include "SUAPI-CppWrapper/model/Entity.hpp"
 
 #include <cassert>
+#include <stdexcept>
+
 #include "SUAPI-CppWrapper/model/AttributeDictionary.hpp"
 
 

--- a/SUAPI-CppWrapper/model/Face.cpp
+++ b/SUAPI-CppWrapper/model/Face.cpp
@@ -26,6 +26,7 @@
 //
 
 #include <cassert>
+#include <stdexcept>
 
 #include <SketchUpAPI/model/edge.h>
 

--- a/SUAPI-CppWrapper/model/ImageRep.cpp
+++ b/SUAPI-CppWrapper/model/ImageRep.cpp
@@ -29,6 +29,7 @@
 #include "SUAPI-CppWrapper/model/ImageRep.hpp"
 
 #include <cassert>
+#include <stdexcept>
 
 namespace CW {
 

--- a/SUAPI-CppWrapper/model/Layer.cpp
+++ b/SUAPI-CppWrapper/model/Layer.cpp
@@ -28,6 +28,8 @@
 #include "SUAPI-CppWrapper/model/Layer.hpp"
 
 #include <cassert>
+#include <stdexcept>
+
 #include "SUAPI-CppWrapper/String.hpp"
 
 

--- a/SUAPI-CppWrapper/model/Loop.cpp
+++ b/SUAPI-CppWrapper/model/Loop.cpp
@@ -34,6 +34,8 @@
 #include "SUAPI-CppWrapper/model/Layer.hpp"
 
 #include <cassert>
+#include <stdexcept>
+
 #include <math.h>
 
 namespace CW {

--- a/SUAPI-CppWrapper/model/Material.cpp
+++ b/SUAPI-CppWrapper/model/Material.cpp
@@ -28,6 +28,8 @@
 #include "SUAPI-CppWrapper/model/Material.hpp"
 
 #include <cassert>
+#include <stdexcept>
+
 #include "SUAPI-CppWrapper/String.hpp"
 #include "SUAPI-CppWrapper/Color.hpp"
 #include "SUAPI-CppWrapper/model/Texture.hpp"

--- a/SUAPI-CppWrapper/model/RenderingOptions.hpp
+++ b/SUAPI-CppWrapper/model/RenderingOptions.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <vector>
+#include <string>
+
 #include <SketchUpAPI/model/rendering_options.h>
 
 namespace CW {

--- a/SUAPI-CppWrapper/model/ShadowInfo.hpp
+++ b/SUAPI-CppWrapper/model/ShadowInfo.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include <SketchUpAPI/model/shadow_info.h>
 
 namespace CW {

--- a/SUAPI-CppWrapper/model/Texture.cpp
+++ b/SUAPI-CppWrapper/model/Texture.cpp
@@ -27,6 +27,7 @@
 
 #include "SUAPI-CppWrapper/model/Texture.hpp"
 #include <cassert>
+#include <stdexcept>
 #include <stdio.h>
 
 #include "SUAPI-CppWrapper/model/ImageRep.hpp"

--- a/SUAPI-CppWrapper/model/Vertex.cpp
+++ b/SUAPI-CppWrapper/model/Vertex.cpp
@@ -28,6 +28,7 @@
 #include "SUAPI-CppWrapper/model/Vertex.hpp"
 
 #include <cassert>
+#include <stdexcept>
 
 namespace CW {
 /******************************


### PR DESCRIPTION
`std::logic_error` is defined in `<stdexcept>` - I had to add these when I built with gcc. 