### PR TITLE
Model::version_string()

### DIFF
--- a/SUAPI-CppWrapper/model/Model.cpp
+++ b/SUAPI-CppWrapper/model/Model.cpp
@@ -110,6 +110,15 @@ bool Model::operator!() const {
   return !bool(*this);
 }
 
+std::string Model::version_string() const
+{
+  int major = 0, minor = 0, build = 0;
+  SUResult res = SUModelGetVersion(m_model, &major, &minor, &build);
+  assert(res == SU_ERROR_NONE);
+  std::string version = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(build);
+  return version;
+}
+
 
 Layer Model::active_layer() const {
   if(!(*this)) {

--- a/SUAPI-CppWrapper/model/Model.hpp
+++ b/SUAPI-CppWrapper/model/Model.hpp
@@ -97,7 +97,7 @@ class Model {
   bool operator!() const;
 
   /**
-  * Returns the model version in the form major.minor.build
+  * Returns a string of the model version in the form "major.minor.build"
   */
   std::string version_string() const;
 

--- a/SUAPI-CppWrapper/model/Model.hpp
+++ b/SUAPI-CppWrapper/model/Model.hpp
@@ -95,7 +95,12 @@ class Model {
   * @return true if the model is invalid
   */
   bool operator!() const;
-  
+
+  /**
+  * Returns the model version in the form major.minor.build
+  */
+  std::string version_string() const;
+
   /*
   * Returns active, or 'default' Layer object
   * @return layer Layer object that is the active layer


### PR DESCRIPTION
This is for me but please merge if you like it.  Adds a function `Model::version_string` that returns the Model's version string like "18.0.16972" 